### PR TITLE
Plot loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ th -ldisplay.start 8000 0.0.0.0
 ```
 Then open `http://(hostname):(port)/` in your browser to load the remote desktop.
 
+L1 error is plotted to the display by default. Set the environment variable `display_plot` to a comma-seperated list of values `errL1`, `errG` and `errD` to visualize the L1, generator, and descriminator error respectively. For example, to plot only the generator and descriminator errors to the display instead of the default L1 error, set `display_plot="errG,errD"`.
+
 ## Citation
 If you use this code for your research, please cite our paper <a href="https://arxiv.org/pdf/1611.07004v1.pdf">Image-to-Image Translation Using Conditional Adversarial Networks</a>:
 

--- a/train.lua
+++ b/train.lua
@@ -416,9 +416,11 @@ for epoch = 1, opt.niter do
             end
 
             -- update display plot
-            table.insert(plot_data, plot_vals)
-            plot_config.win = plot_win
-            plot_win = disp.plot(plot_data, plot_config)
+            if opt.display then
+              table.insert(plot_data, plot_vals)
+              plot_config.win = plot_win
+              plot_win = disp.plot(plot_data, plot_config)
+            end
         end
         
         -- save latest model

--- a/train.lua
+++ b/train.lua
@@ -314,6 +314,16 @@ file = torch.DiskFile(paths.concat(opt.checkpoints_dir, opt.name, 'opt.txt'), 'w
 file:writeObject(opt)
 file:close()
 
+-- display plot config
+local plot_config = {
+  title = "Loss over time",
+  labels = {"epoch", "errG", "errD", "errL1"},
+  ylabel = "loss",
+}
+-- display plot vars
+local plot_data = {}
+local plot_win
+
 local counter = 0
 for epoch = 1, opt.niter do
     epoch_tm:reset()
@@ -328,7 +338,7 @@ for epoch = 1, opt.niter do
         
         -- (2) Update G network: maximize log(D(x,G(x))) + L1(y,G(x))
         optim.adam(fGx, parametersG, optimStateG)
-        
+
         -- display
         counter = counter + 1
         if counter % opt.display_freq == 0 and opt.display then
@@ -385,6 +395,10 @@ for epoch = 1, opt.niter do
                      math.floor(math.min(data:size(), opt.ntrain) / opt.batchSize),
                      tm:time().real / opt.batchSize, data_tm:time().real / opt.batchSize,
                      errG and errG or -1, errD and errD or -1, errL1 and errL1 or -1))
+            -- update display plot
+            table.insert(plot_data, {epoch, errG, errD, errL1})
+            plot_config.win = plot_win
+            plot_win = disp.plot(plot_data, plot_config)
         end
         
         -- save latest model

--- a/util/util.lua
+++ b/util/util.lua
@@ -219,4 +219,11 @@ function util.cudnn(net)
 	return cudnn_convert_custom(net, cudnn)
 end
 
+function util.containsValue(table, value)
+  for k, v in pairs(table) do 
+    if v == value then return true end
+  end
+  return false
+end
+
 return util


### PR DESCRIPTION
Add `errL1`, `errG`, and `errD` loss plotting support in the display UI through the `display_plot` environment variable in `train.lua`. By default, only `errL1` is plotted, however `errG` and `errD` can be plotted instead with `display_plot="errG,errD"`. Hoping to include other error metrics like SSIM in the future. 

Related to https://github.com/phillipi/pix2pix/issues/21.