### PR TITLE
Use range instead of linspace to generate classList

### DIFF
--- a/data/dataset.lua
+++ b/data/dataset.lua
@@ -240,7 +240,7 @@ function dataset:__init(...)
       if length == 0 then
          error('Class has zero samples')
       else
-         self.classList[i] = torch.linspace(runningIndex + 1, runningIndex + length, length):long()
+         self.classList[i] = torch.range(runningIndex + 1, runningIndex + length):long()
          self.imageClass[{{runningIndex + 1, runningIndex + length}}]:fill(i)
       end
       runningIndex = runningIndex + length


### PR DESCRIPTION
On my machine, when running test.lua, the old code will have several duplicates for 7056 images, which results in images from val folder not appearing in the results. When changing to range there is no longer any problem.