### PR TITLE
Ignore hidden folders for combine_A_and_B.py script

### DIFF
--- a/scripts/combine_A_and_B.py
+++ b/scripts/combine_A_and_B.py
@@ -15,12 +15,12 @@ args = parser.parse_args()
 for arg in vars(args):
     print('[%s] = ' % arg,  getattr(args, arg))
 
-splits = os.listdir(args.fold_A)
+splits = filter( lambda f: not f.startswith('.'), os.listdir(args.fold_A)) # ignore hidden folders like .DS_Store
 
 for sp in splits:
     img_fold_A = os.path.join(args.fold_A, sp)
     img_fold_B = os.path.join(args.fold_B, sp)
-    img_list = os.listdir(img_fold_A)
+    img_list = filter( lambda f: not f.startswith('.'), os.listdir(img_fold_A)) # ignore hidden folders like .DS_Store
     if args.use_AB: 
         img_list = [img_path for img_path in img_list if '_A.' in img_path]
 


### PR DESCRIPTION
Small change for something that has been annoying me. 

Ignores hidden folders like `.DS_Store`. Not sure its an issue for non Mac users. 

