### PR TITLE
Fix data/dataset.lua LuaJit Dependency Problem on mac

### DIFF
--- a/data/dataset.lua
+++ b/data/dataset.lua
@@ -145,7 +145,7 @@ function dataset:__init(...)
    local wc = 'wc'
    local cut = 'cut'
    local find = 'find -H'  -- if folder name is symlink, do find inside it after dereferencing
-   if jit.os == 'OSX' then
+   if ffi.os == 'OSX' then
       wc = 'gwc'
       cut = 'gcut'
       find = 'gfind'


### PR DESCRIPTION
Fix data/dataset.lua LuaJit dependency problem on mac which results the error `attempt to index global 'jit' (a nil value)`

This pull request is the same as the following pull request:
https://github.com/junyanz/CycleGAN/pull/6